### PR TITLE
Update folder flattening so 'World' flattening does not reorder items

### DIFF
--- a/Assets/Hierarchy 2/Runtime/HierarchyFolder.cs
+++ b/Assets/Hierarchy 2/Runtime/HierarchyFolder.cs
@@ -49,7 +49,7 @@ namespace Hierarchy2
 
             var parent = flattenSpace == FlattenSpace.World ? null : transform.parent;
             var childCount = transform.childCount;
-            var parentOrderIndex = transform.GetSiblingIndex();
+            var parentOrderIndex = flattenSpace == FlattenSpace.World ? transform.root.GetSiblingIndex() : transform.GetSiblingIndex();
 
             while (childCount-- > 0)
             {


### PR DESCRIPTION
First, thank you for making this project available, it has been incredibly helpful in keeping my scenes organized!

While playing around with the folder options, I noticed that if you have folders nested under another object and the flattening method set to "World", it moves the objects to (usually) much earlier in the hierarchy, potentially affecting the render order of objects in the scene.

This is just a small change to use the hierarchy index of the root object, rather than the object itself, to position the "world" flattened hierarchy.  It still does not perfectly preserve the ordering of all nested objects (which depends on the order in which the folder scripts run), but it does prevent large changes in hierarchy position.