### PR TITLE
Add max components setting

### DIFF
--- a/Assets/Hierarchy 2/Editor/HierarchyEditor.cs
+++ b/Assets/Hierarchy 2/Editor/HierarchyEditor.cs
@@ -907,7 +907,7 @@ namespace Hierarchy2
                 }
             }
 
-            int length = components.Count;
+            int length = components.Count < settings.maxComponents || settings.displayEveryComponent ? components.Count : settings.maxComponents ;
             bool separator = false;
             float widthUsedCached = 0;
             if (settings.componentAlignment == HierarchySettings.ElementAlignment.AfterName)

--- a/Assets/Hierarchy 2/Editor/HierarchyEditor.cs
+++ b/Assets/Hierarchy 2/Editor/HierarchyEditor.cs
@@ -907,7 +907,7 @@ namespace Hierarchy2
                 }
             }
 
-            int length = components.Count < settings.maxComponents || settings.displayEveryComponent ? components.Count : settings.maxComponents ;
+            int length = components.Count < settings.maxComponents || settings.enableMaxComponents ? components.Count : settings.maxComponents ;
             bool separator = false;
             float widthUsedCached = 0;
             if (settings.componentAlignment == HierarchySettings.ElementAlignment.AfterName)

--- a/Assets/Hierarchy 2/Editor/HierarchySettings.cs
+++ b/Assets/Hierarchy 2/Editor/HierarchySettings.cs
@@ -145,6 +145,8 @@ namespace Hierarchy2
         [HideInInspector] public int componentLimited = 0;
         [Range(12, 16)] public int componentSize = 16;
         public int componentSpacing = 0;
+        public bool displayEveryComponent = true;
+        public int maxComponents = 10;
         public bool displayTag = true;
         public ElementAlignment tagAlignment = ElementAlignment.AfterName;
         public bool displayLayer = true;
@@ -176,6 +178,10 @@ namespace Hierarchy2
 
                 case nameof(componentSpacing):
                     if (componentSpacing < 0) componentSpacing = 0;
+                    break;
+                
+                case nameof(maxComponents):
+                    if (maxComponents < 0) maxComponents = 0;
                     break;
             }
 
@@ -416,6 +422,31 @@ namespace Hierarchy2
                         settings.OnSettingsChanged(nameof(settings.componentSpacing));
                     });
                     verticalLayout.Add(componentSpacing);
+                    
+                    var displayEveryComponent = new Toggle("Display Every Component");
+                    displayEveryComponent.value = settings.displayEveryComponent;
+                    displayEveryComponent.RegisterValueChangedCallback((evt) =>
+                    {
+                        Undo.RecordObject(settings, "Change Settings");
+
+                        settings.displayEveryComponent = evt.newValue;
+                        settings.OnSettingsChanged(nameof(settings.displayEveryComponent));
+                    });
+                    displayEveryComponent.StyleMarginLeft(CONTENT_MARGIN_LEFT);
+                    verticalLayout.Add(displayEveryComponent);
+                    
+                    var maxComponents = new IntegerField();
+                    maxComponents.label = "Max Components";
+                    maxComponents.value = settings.maxComponents;
+                    maxComponents.StyleMarginLeft(CONTENT_MARGIN_LEFT);
+                    maxComponents.RegisterValueChangedCallback((evt) =>
+                    {
+                        Undo.RecordObject(settings, "Change Settings");
+
+                        settings.maxComponents = evt.newValue;
+                        settings.OnSettingsChanged(nameof(settings.maxComponents));
+                    });
+                    verticalLayout.Add(maxComponents);
 
                     var TagAndLayer = new Label("Tag And Layer");
                     TagAndLayer.StyleFont(FontStyle.Bold);

--- a/Assets/Hierarchy 2/Editor/HierarchySettings.cs
+++ b/Assets/Hierarchy 2/Editor/HierarchySettings.cs
@@ -145,7 +145,7 @@ namespace Hierarchy2
         [HideInInspector] public int componentLimited = 0;
         [Range(12, 16)] public int componentSize = 16;
         public int componentSpacing = 0;
-        public bool displayEveryComponent = true;
+        public bool enableMaxComponents = false;
         public int maxComponents = 10;
         public bool displayTag = true;
         public ElementAlignment tagAlignment = ElementAlignment.AfterName;
@@ -423,17 +423,17 @@ namespace Hierarchy2
                     });
                     verticalLayout.Add(componentSpacing);
                     
-                    var displayEveryComponent = new Toggle("Display Every Component");
-                    displayEveryComponent.value = settings.displayEveryComponent;
-                    displayEveryComponent.RegisterValueChangedCallback((evt) =>
+                    var enableMaxComponents = new Toggle("Enable Max Components");
+                    enableMaxComponents.value = settings.enableMaxComponents;
+                    enableMaxComponents.RegisterValueChangedCallback((evt) =>
                     {
                         Undo.RecordObject(settings, "Change Settings");
 
-                        settings.displayEveryComponent = evt.newValue;
-                        settings.OnSettingsChanged(nameof(settings.displayEveryComponent));
+                        settings.enableMaxComponents = evt.newValue;
+                        settings.OnSettingsChanged(nameof(settings.enableMaxComponents));
                     });
-                    displayEveryComponent.StyleMarginLeft(CONTENT_MARGIN_LEFT);
-                    verticalLayout.Add(displayEveryComponent);
+                    enableMaxComponents.StyleMarginLeft(CONTENT_MARGIN_LEFT);
+                    verticalLayout.Add(enableMaxComponents);
                     
                     var maxComponents = new IntegerField();
                     maxComponents.label = "Max Components";


### PR DESCRIPTION
Useful feature: Be able to limit the number of components that are shown. 
Reason: If a component has too many components it quickly bloats the hierarchy, resulting in component icons obscuring everything else.

This max components setting modifies the hierarchy to only show the first _nth_ components found on the GameObject. In order to keep functionality the same as previously, by default the enableMaxComponents boolean is false, which always shows all components.