### PR TITLE
add folder to hierarchy context menu

### DIFF
--- a/Assets/Hierarchy 2/Editor/HierarchyFolderEditor.cs
+++ b/Assets/Hierarchy 2/Editor/HierarchyFolderEditor.cs
@@ -36,6 +36,7 @@ namespace Hierarchy2
         }
 
         [MenuItem("Tools/Hierarchy 2/Hierarchy Folder", priority = 0)]
+        [MenuItem("GameObject/Hierarchy Folder", priority = 0)]
         static void CreateInstance(UnityEditor.MenuCommand command)
         {
             GameObject gameObject = new GameObject("Folder", new Type[1] {typeof(HierarchyFolder)});


### PR DESCRIPTION
One line change to add the Folders to the Hierarchy's context menu.
Also adds it to the  list of other items you can add from the "Game Object" menu.

This just feels like a another good place for the "New folder" button to be, and smooths the process of organizing your heirarchy.